### PR TITLE
Fix dark theme contrast and eliminate ghosted text layer

### DIFF
--- a/media/viewer.css
+++ b/media/viewer.css
@@ -123,11 +123,17 @@ main {
   transform-origin: 0% 0%;
   white-space: pre;
   pointer-events: auto;
-  color: var(--text-layer-color, #000);
+  color: transparent;
 }
 
 .textLayer span::selection {
+  color: #111;
   background: rgba(0, 102, 184, 0.35);
+}
+
+body[data-theme='dark'] .textLayer span::selection {
+  color: #f5f5f5;
+  background: rgba(124, 176, 255, 0.45);
 }
 
 .error {
@@ -165,6 +171,14 @@ body[data-theme='dark'] .toolbar button {
 
 body[data-theme='dark'] .toolbar button:hover {
   background: rgba(32, 35, 45, 1);
+}
+
+body[data-theme='dark'] .pdf-canvas {
+  filter: invert(0.92) hue-rotate(180deg);
+}
+
+body[data-theme='dark'] .pdf-page__surface {
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
 }
 
 body[data-theme='dark'] .placeholder {


### PR DESCRIPTION
## Summary
- hide the PDF.js text layer glyphs so rendered pages no longer show doubled text
- adjust selection colours for light and dark modes to keep text legible when highlighted
- apply a dark-theme canvas filter and shadow tweak for better contrast in night mode

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68dc9ab6b2f08330957a6427138c6e39