### PR TITLE
Tint paper theme pages with sandy overlay

### DIFF
--- a/media/viewer.css
+++ b/media/viewer.css
@@ -220,6 +220,19 @@ body[data-theme='paper'] .toolbar button:hover {
   background: rgba(255, 255, 255, 1);
 }
 
+body[data-theme='paper'] .pdf-page__surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      135deg,
+      rgba(240, 227, 198, 0.65),
+      rgba(233, 216, 178, 0.45)
+    );
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
 body[data-theme='paper'] .placeholder {
   color: rgba(59, 47, 26, 0.75);
   background: rgba(254, 251, 242, 0.9);


### PR DESCRIPTION
## Summary
- add a sandy gradient overlay to PDF page surfaces when the Paper Sand theme is active
- ensure the overlay does not interfere with interactions by disabling pointer events

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd45a9ee28833090c03c01e0c31967