### PR TITLE
Update Sand theme naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dunkel PDF Viewer
 
-Dunkel PDF Viewer is a Visual Studio Code extension that renders PDFs in a themed webview. It ships with three viewing modes—Regular, Dark, and Paper Sand—so you can choose the reading experience that best matches your environment.
+Dunkel PDF Viewer is a Visual Studio Code extension that renders PDFs in a themed webview. It ships with three viewing modes—Regular, Dark, and Sand—so you can choose the reading experience that best matches your environment.
 
 ## Features
 
@@ -47,7 +47,7 @@ npm run watch
 
 - `Dunkel PDF: Use Regular Theme`
 - `Dunkel PDF: Use Dark Theme`
-- `Dunkel PDF: Use Paper Sand Theme`
+- `Dunkel PDF: Use Sand Theme`
 
 These commands update every open Dunkel PDF panel to use the selected theme. The same theme buttons are also available inside the viewer toolbar.
 

--- a/out/extension.js
+++ b/out/extension.js
@@ -138,7 +138,7 @@ class PdfViewerProvider {
             <div class="toolbar__group">
               <button data-theme="regular">Regular</button>
               <button data-theme="dark">Dark</button>
-              <button data-theme="paper">Paper Sand</button>
+              <button data-theme="paper">Sand</button>
             </div>
             <div class="toolbar__group">
               <input id="zoomRange" type="range" min="50" max="200" value="100" />

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       },
       {
         "command": "dunkelpdf.theme.paper",
-        "title": "Dunkel PDF: Use Paper Sand Theme"
+        "title": "Dunkel PDF: Use Sand Theme"
       },
       {
         "command": "dunkelpdf.theme.regular",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,7 @@ class PdfViewerProvider implements vscode.CustomReadonlyEditorProvider<PdfDocume
             <div class="toolbar__group">
               <button data-theme="regular">Regular</button>
               <button data-theme="dark">Dark</button>
-              <button data-theme="paper">Paper Sand</button>
+              <button data-theme="paper">Sand</button>
             </div>
             <div class="toolbar__group">
               <input id="zoomRange" type="range" min="50" max="200" value="100" />


### PR DESCRIPTION
## Summary
- rename the Paper Sand theme label to Sand across the extension UI and documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5e129bc48330ae4a658199a3a52c