### PR TITLE
Preserve context menu page before hiding

### DIFF
--- a/media/viewer.js
+++ b/media/viewer.js
@@ -133,6 +133,7 @@
           return;
         }
 
+        const savedPage = contextMenuPage;
         const command = button.getAttribute('data-command');
         if (!command) {
           hideContextMenu();
@@ -144,9 +145,13 @@
 
         hideContextMenu();
 
+        if (savedPage === null || savedPage === undefined) {
+          return;
+        }
+
         vscode.postMessage({
           type: command,
-          page: contextMenuPage,
+          page: savedPage,
           text: selection
         });
       });


### PR DESCRIPTION
## Summary
- capture the context menu page number before hiding the menu
- reuse the saved page when posting commands and guard against missing values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd769b5a648330b197d7bfafc93b40