### PR TITLE
Render annotation panels alongside PDF pages

### DIFF
--- a/media/viewer.css
+++ b/media/viewer.css
@@ -143,7 +143,9 @@ main {
 .pdf-page {
   width: 100%;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .pdf-page__surface {
@@ -154,6 +156,7 @@ main {
   overflow: hidden;
   background: var(--page-bg, #fff);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
+  align-self: center;
 }
 
 .pdf-page--bookmarked .pdf-page__surface {
@@ -188,6 +191,60 @@ main {
 .textLayer span::selection {
   color: #111;
   background: rgba(0, 102, 184, 0.35);
+}
+
+.pdf-page__annotations {
+  align-self: stretch;
+  width: 100%;
+  max-width: 720px;
+  box-sizing: border-box;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(4px);
+  padding: 0.75rem 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.pdf-page__annotations[hidden] {
+  display: none;
+}
+
+.pdf-annotations__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pdf-annotations__heading {
+  margin: 0;
+  font-size: 0.95em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(0, 0, 0, 0.75);
+}
+
+.pdf-annotations__list {
+  list-style: disc;
+  margin: 0 0 0 1.25rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pdf-annotations__item {
+  margin: 0;
+  color: inherit;
+  word-break: break-word;
 }
 
 .context-menu {


### PR DESCRIPTION
## Summary
- map incoming note and quote annotations per page in the viewer and trigger re-rendering when data changes
- attach an annotations container to each page view so notes and quotes appear alongside the PDF content
- style the annotation container for readability and scrolling without covering the canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd772a76cc83309c1c72dcd2781146