### PR TITLE
Add packaging ignore file to prevent oversized VSIX uploads

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,17 @@
+# Exclude source and development artifacts from the packaged extension
+.vscode/**
+node_modules/**
+.vscode-test/**
+.git/**
+.gitignore
+npm-debug.log*
+package-lock.json
+src/**
+**/*.ts
+out/**/*.map
+media/**/*.map
+**/*.test.*
+**/*.spec.*
+
+# Ignore generated VSIX bundles and metadata
+*.vsix

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ These commands update every open Dunkel PDF panel to use the selected theme. The
    npx vsce publish
    ```
 
+### Troubleshooting packaging issues
+
+If the Marketplace upload fails with a `TF400898` internal error, the VSIX is
+usually too large. Double-check that a [`.vscodeignore`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#ignore-things-from-being-published)
+file exists so development folders such as `node_modules/` or `src/` are not
+bundled in the package. The repository already includes one, so running
+`npm run package` should produce a VSIX that is only a few kilobytes in size.
+
 ## Editing Tips
 
 - All extension source code lives in `src/`. The entry point is `src/extension.ts`.


### PR DESCRIPTION
## Summary
- add a .vscodeignore file so packaging excludes development dependencies and source
- document how the ignore file resolves TF400898 upload failures in the README

## Testing
- npm run package

------
https://chatgpt.com/codex/tasks/task_e_68e03ffcfe1c8330b18a514635913399