### PR TITLE
Fix annotation context menu interactions

### DIFF
--- a/media/viewer.js
+++ b/media/viewer.js
@@ -298,6 +298,10 @@
         return;
       }
 
+      if (target.closest('.pdf-annotations__item')) {
+        return;
+      }
+
       const surface = target.closest('.pdf-page__surface');
       if (!surface) {
         hideContextMenu();
@@ -1824,6 +1828,7 @@
 
     element.addEventListener('contextmenu', event => {
       event.preventDefault();
+      event.stopPropagation();
       if (!contextMenu) {
         return;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dunkelpdf",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dunkelpdf",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "pdfjs-dist": "^5.4.149"
       },


### PR DESCRIPTION
## Summary
- prevent the page-level context-menu handler from closing the menu when right-clicking annotation items
- stop event propagation from note and quote list items so their remove actions stay available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ef272a648330b3c10386a9f6a7e0