### PR TITLE
Clarify metadata branding for data-science focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dunkelpdf",
   "displayName": "dunkelPDF",
-  "description": "",
+  "description": "Definitive PDF reader for data science workflows with search, outlines, annotations, and footnote previews.",
   "version": "0.0.5",
   "publisher": "dunkel000",
   "icon": "assets/icon.png",
@@ -36,7 +36,7 @@
     "customEditors": [
       {
         "viewType": "dunkelpdf.viewer",
-        "displayName": "Dunkel PDF Viewer",
+        "displayName": "dunkelPDF Data Science Viewer",
         "selector": [
           {
             "filenamePattern": "*.pdf"


### PR DESCRIPTION
## Summary
- add a descriptive tagline that positions the extension as the definitive PDF reader for data science workflows
- rename the custom editor label to highlight the data-science focus without changing the extension name

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e4657874e483309e74a5e9abd51d13